### PR TITLE
fix: add .gitattributes to enforce LF line endings for shell scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Ensure shell scripts always use LF line endings on all platforms
+*.sh text eol=lf
+
+# Ensure other text files maintain consistent line endings
+* text=auto


### PR DESCRIPTION
## Summary
This PR fixes issue #7 where `entrypoint.sh` was not found on Windows 11 due to CRLF line endings.

## Changes
- Added `.gitattributes` file to enforce LF line endings for all shell scripts
- Ensures cross-platform compatibility for Windows, macOS, and Linux

## Testing
After merging, Windows users should:
1. Pull latest changes
2. Delete and re-clone the repository
3. Rebuild Docker images: `docker-compose build --no-cache`
4. Run: `docker-compose up -d`

Closes #7

---
Generated with [Claude Code](https://claude.ai/code)